### PR TITLE
Fixed Dupe Glitch

### DIFF
--- a/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
+++ b/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
@@ -113,7 +113,7 @@ class EventListener implements Listener {
 	public function onQuit(PlayerQuitEvent $event) {
 		$player = $event->getPlayer();
 		if($this->plugin->isTagged($player) and $this->killOnLog) {
-			$player->kill();
+			$player->setHealth(0);
 		}
 	}
 


### PR DESCRIPTION
Fixed the dupe glitch with CombatLogger. Replaced with $player->kill(); with $player->setHealth(0); because kill() is buggy asf.