### PR TITLE
Command bypass by spaces

### DIFF
--- a/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
+++ b/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
@@ -101,13 +101,8 @@ class EventListener implements Listener {
 			if ($message{0} == "/") $offset = 1; // /comand
 			elseif (substr($message, 0, 2) == "./") $offset = 2; // ./comand
 			else return; //not command
-			if(count(explode(' ', substr($message, $offset))) > 1){
-				foreach(explode(' ', substr($message, $offset)) as $worlds){
-					if(!empty($worlds)) break;
-					$offset++;
-				}
-			}
-			$label = explode(' ', substr($message, $offset))[0];
+			
+			$label = explode(' ', trim(substr($message, $offset)))[0];
 			$command = $this->plugin->getServer()->getCommandMap()->getCommand($label);
 			if ($command instanceof Command and in_array($command->getName(), $this->bannedCommands)) {
 				$event->setCancelled();

--- a/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
+++ b/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
@@ -98,14 +98,20 @@ class EventListener implements Listener {
 		$player = $event->getPlayer();
 		if($this->plugin->isTagged($player)) {
 			$message = $event->getMessage();
-			if(strpos($message, "/") === 0) {
-				$args = array_map("stripslashes", str_getcsv(substr($message, 1), " "));
-				$label = "";
-				$target = $this->plugin->getServer()->getCommandMap()->matchCommand($label, $args);
-				if($target instanceof Command and in_array(strtolower($label), $this->bannedCommands)) {
-					$event->setCancelled();
-					$player->sendMessage($this->plugin->getMessageManager()->getMessage("player-run-banned-command"));
+			if ($message{0} == "/") $offset = 1; // /comand
+			elseif (substr($message, 0, 2) == "./") $offset = 2; // ./comand
+			else return; //not command
+			if(count(explode(' ', substr($message, $offset))) > 1){
+				foreach(explode(' ', substr($message, $offset)) as $worlds){
+					if(!empty($worlds)) break;
+					$offset++;
 				}
+			}
+			$label = explode(' ', substr($message, $offset))[0];
+			$command = $this->plugin->getServer()->getCommandMap()->getCommand($label);
+			if ($command instanceof Command and in_array($command->getName(), $this->bannedCommands)) {
+				$event->setCancelled();
+				$player->sendMessage($this->plugin->getMessageManager()->getMessage("player-run-banned-command"));
 			}
 		}
 	}

--- a/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
+++ b/CombatLogger/src/jacknoordhuis/combatlogger/EventListener.php
@@ -25,6 +25,10 @@ use pocketmine\event\player\PlayerCommandPreprocessEvent;
 use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerQuitEvent;
 use pocketmine\Player;
+use function explode;
+use function in_array;
+use function substr;
+use function trim;
 
 class EventListener implements Listener {
 


### PR DESCRIPTION
fixed the possibility to execute commands by putting spaces.
exemple:
if i ban "/god"      "/      god" work.
