### PR TITLE
Null Input Crash

### DIFF
--- a/CombatLogger/resources/Settings.yml
+++ b/CombatLogger/resources/Settings.yml
@@ -11,6 +11,7 @@ banned-commands:
   - tpa
   - spawn
 messages:
+ invalid-command: "&c- Invalid command entry!"
  player-tagged: "&c- &6You are now in combat, do not logout or you will be punished!"
  player-tagged-timeout: "&6- &aYou are no longer in combat!"
  player-run-banned-command: "&c- &6You cannot execute this command whilst in combat!"

--- a/CombatLogger/src/JackNoordhuis/CombatLogger/EventListener.php
+++ b/CombatLogger/src/JackNoordhuis/CombatLogger/EventListener.php
@@ -92,6 +92,7 @@ class EventListener implements Listener {
 	 */
 	public function onCommandEvent(CommandEvent $event) {
 		$player = $event->getSender();
+		$command = $event->getCommand();
 		if(!($player instanceof Player) or !$this->plugin->isTagged($player)) {
 			return;
 		}
@@ -108,6 +109,11 @@ class EventListener implements Listener {
 			}
 		}
 
+		$trimmed = trim($command);
+		if($trimmed === "") {
+			$player->sendMessage($this->plugin->getFormattedMessage('invalid-command'));
+			return;
+		}
 		$command = $this->plugin->getServer()->getCommandMap()->getCommand($args[0]);
 		if($command !== null) {
 			$args[0] = $command->getName();


### PR DESCRIPTION
What this does:
- Stops command with no input from crashing the server
- Trims blank message — (/ )
- Added invalid-command in Settings.yml